### PR TITLE
Rename typed expressions to C and Q

### DIFF
--- a/src/parser/typed.fs
+++ b/src/parser/typed.fs
@@ -16,57 +16,65 @@ and QType =
     | QBool
     | QInt
 
-type TypedExpression =
+type C =
     | Var of string * Type
 
     | BoolLiteral of bool * Type
     | IntLiteral of int * Type
-    | Tuple of values: TypedExpression list * Type
-    | Set of  values: TypedExpression list * Type
-    | Range of  start: TypedExpression * stop: TypedExpression * Type
+    | Tuple of values: C list * Type
+    | Set of  values: C list * Type
+    | Range of  start: C * stop: C * Type
 
-    | Not of TypedExpression * Type
-    | And of TypedExpression * TypedExpression * Type
-    | Or of TypedExpression * TypedExpression * Type
-    | Equals of TypedExpression * TypedExpression * Type
-    | LessThan of TypedExpression * TypedExpression * Type
+    | Not of C * Type
+    | And of C * C * Type
+    | Or of C * C * Type
+    | Equals of C * C * Type
+    | LessThan of C * C * Type
 
-    | Add of TypedExpression * TypedExpression * Type
-    | Multiply of TypedExpression * TypedExpression * Type
+    | Add of C * C * Type
+    | Multiply of C * C * Type
 
-    | Method of name: Id * arguments: Id list * body: TypedExpression * Type
-    | CallMethod of method: TypedExpression * arguments: TypedExpression list * Type
+    | Method of name: Id * arguments: Id list * body: C * Type
+    | CallMethod of method: C * arguments: C list * Type
 
-    | Join of values: TypedExpression list * Type
-    | Project of source: TypedExpression * indices: TypedExpression list * Type
-    | Block of Statement list * value: TypedExpression * Type
-    | If of cond: TypedExpression * t : TypedExpression * f: TypedExpression * Type
-    | Summarize of id: Id * enumeration : TypedExpression * operation: TypedExpression * body: TypedExpression * Type
+    | Join of values: C list * Type
+    | Project of source: C * indices: C list * Type
+    | Block of stmts: Statement list * value: C * Type
+    | If of cond: C * t : C * f: C * Type
+    | Summarize of id: Id * enumeration : C * operation: C * body: C * Type
 
-    | CallQMethod of method: TypedExpression * arguments: TypedExpression list * qarguments: QTypedExpression list * QType
+    | CallQMethod of method: C * arguments: C list * qarguments: Q list * QType
 
-    | Sample of ket: QTypedExpression * Type
-    | Measure of ket: QTypedExpression * shots: TypedExpression * Type
-    | Solve of ket: QTypedExpression * shots: TypedExpression * QType
+    | Sample of ket: Q * Type
+    | Measure of ket: Q * shots: C * Type
+    | Solve of ket: Q * shots: C * QType
 
-and QTypedExpression =
+and Q =
     | Var of string * QType
 
-    | Constant of TypedExpression * QType
+    | Constant of C * QType
     | AllKet of size: int * QType
 
-    | Not of QTypedExpression * QType
-    | And of QTypedExpression * QTypedExpression * QType
-    | Or of QTypedExpression * QTypedExpression * QType
-    | Equals of QTypedExpression * QTypedExpression * QType
+    | Not of Q * QType
+    | And of Q * Q * QType
+    | Or of Q * Q * QType
+    | Equals of Q * Q * QType
 
-    | Add of QTypedExpression * QTypedExpression * QType
-    | Multiply of QTypedExpression * QTypedExpression * QType
+    | Add of Q * Q * QType
+    | Multiply of Q * Q * QType
 
-    | Join of values: QTypedExpression list * QType
-    | Project of source: QTypedExpression * indices: TypedExpression list * QType
-    | Block of Statement list * QTypedExpression * QType
-    | If of cond: QTypedExpression * t : QTypedExpression * f: QTypedExpression * QType
-    | Summarize of id: Id * enumeration : TypedExpression * operation: TypedExpression * body: QTypedExpression * QType
+    | Join of values: Q list * QType
+    | Project of source: Q * indices: C list * QType
+    | Block of qstmts: Statement list * Q * QType
+    | If of cond: Q * t : Q * f: Q * QType
+    | Summarize of id: Id * enumeration : C * operation: C * body: Q * QType
 
-    | CallQMethod of method: TypedExpression * arguments: TypedExpression list * qarguments: QTypedExpression list * QType
+    | CallQMethod of method: C * arguments: C list * qarguments: Q list * QType
+
+and E =
+    | Classic of C
+    | Quantum of Q
+
+and Statement =
+    | Let of id: Id * value: E
+    | Print of Id * E list


### PR DESCRIPTION
Simply renaming TypedExpression -> C and QTypedExpression -> Q. This just makes the code easier/faster to read.
Can switch back to full descriptive name later.